### PR TITLE
Update doc gen makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,10 @@ src/ros2/rclcpp/rclcpp/doc_output/html doxygen_tag_files/rclcpp.tag: src/ros2/rc
 	rm -r doc_output || true
 	rm doxygen_tag_files/rclcpp.tag || true
 	cd src/ros2/rclcpp/rclcpp && doxygen Doxyfile
+
+cpp-doxygen-web.tag.xml:
+	test -d doxygen_tag_files || mkdir doxygen_tag_files
+	wget 'http://upload.cppreference.com/mwiki/images/f/f8/cppreference-doxygen-web.tag.xml' \
+		-O doxygen_tag_files/cppreference-doxygen-web.tag.xml
+
+setup: cpp-doxygen-web.tag.xml

--- a/Makefile
+++ b/Makefile
@@ -43,22 +43,38 @@ src/ros2/ros_core_documentation/build/html: src/ros2/ros_core_documentation/Make
 	cd src/ros2/ros_core_documentation && make html
 
 src/ros2/rcutils/doc_output/html doxygen_tag_files/rcutils.tag: src/ros2/rcutils/Doxyfile
+	. install/setup.sh && \
+		cd src/ros2/rcutils && \
+		git clean -dfx && \
+		cmake . && make
 	rm -r $@ || true
 	rm doxygen_tag_files/rcutils.tag || true
 	cd src/ros2/rcutils && doxygen Doxyfile
 
 src/ros2/rmw/rmw/doc_output/html doxygen_tag_files/rmw.tag: src/ros2/rmw/rmw/Doxyfile doxygen_tag_files/rcutils.tag
-	rm -r doc_output || true
+	. install/setup.sh && \
+		cd src/ros2/rmw/rmw && \
+		git clean -dfx && \
+		cmake . && make
+	rm -r $@ || true
 	rm doxygen_tag_files/rmw.tag || true
 	cd src/ros2/rmw/rmw && doxygen Doxyfile
 
 src/ros2/rcl/rcl/doc_output/html doxygen_tag_files/rcl.tag: src/ros2/rcl/rcl/Doxyfile doxygen_tag_files/rcutils.tag doxygen_tag_files/rmw.tag
-	rm -r doc_output || true
+	. install/setup.sh && \
+		cd src/ros2/rcl/rcl && \
+		git clean -dfx && \
+		cmake . && make
+	rm -r $@ || true
 	rm doxygen_tag_files/rcl.tag || true
 	cd src/ros2/rcl/rcl && doxygen Doxyfile
 
 src/ros2/rclcpp/rclcpp/doc_output/html doxygen_tag_files/rclcpp.tag: src/ros2/rclcpp/rclcpp/Doxyfile doxygen_tag_files/rcl.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcutils.tag
-	rm -r doc_output || true
+	. install/setup.sh && \
+		cd src/ros2/rclcpp/rclcpp && \
+		git clean -dfx && \
+		cmake . && make
+	rm -r $@ || true
 	rm doxygen_tag_files/rclcpp.tag || true
 	cd src/ros2/rclcpp/rclcpp && doxygen Doxyfile
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-release_name := ardent
+release_name := crystal
 
 default: $(release_name) api/rcutils api/rmw api api/rcl api/rclcpp
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@
   - Import the documentation repos into the workspace with `vcs import src < ros2_doc.repos`
   - Update ros2/ros_core_documentation as appropriate; install dependencies mentioned in its readme and Doxygen.
     - Specifically you'll want to update the release name, see: https://github.com/ros2/ros_core_documentation/pull/7
-  - `mkdir doxygen_tag_files`and download external tag files there, e.g. http://en.cppreference.com/w/File:cppreference-doxygen-web.tag.xml (at Ardent that was the only one).
-  - Update the Doxyfile of all packages listed in the makefile:
+  - Update the Doxyfile of all packages listed in the Makefile:
     - Uncomment the relevant line so that they will generate tag files.
     - Change the ROS 2 `TAGFILES` links so that they reference `docs.ros2.org/<release name>` instead of `latest`.
-  - For each package that needs to document generated code (only `rcutils` and `rclcpp` at Ardent), install the package and uncomment the lines in its Doxyfile to allow reference to the generated files.
-  - Run `make install` from the base of the workspace. This will generate and copy the docs into `src/ros2/docs.ros2.org/<release_name>`.
+  - Run `make install` from the base of the workspace.
+    This will build documented repositories in place to support generated code and then generate and copy the docs into `src/ros2/docs.ros2.org/<release_name>`.
   - Check that the following are working:
     - Cross-references between packages, e.g. `rmw` links from `rcl` docs.
     - External references, e.g. references to cppreference.com for `std::string`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## Generating static docs for a ros2 release
 
-  - Download the Makefile to the base of a ros2 workspace.
-  - Update the release name in the makefile.
+  - Build up to rclcpp in a clean ros2 workspace.
+  - Download the Makefile to the base of that workspace or apply `-f PATH/TO/Makefile` to all `make` invocations below.
+  - Update the release name in the Makefile.
   - Import the documentation repos into the workspace with `vcs import src < ros2_doc.repos`
   - Update ros2/ros_core_documentation as appropriate; install dependencies mentioned in its readme and Doxygen.
     - Specifically you'll want to update the release name, see: https://github.com/ros2/ros_core_documentation/pull/7


### PR DESCRIPTION
New things:

* The Makefile now creates the doxygen_tag_files directory if it doesn't exist and fetches the tags file from cppreference for as long as that URL is valid
* Builds each package in-place with `cmake . && make` for documenting generated code.

It still isn't a good Makefile and the next time I feel like writing Make at 2AM I'll probably try to get it autopatching the Doxyfiles to replace `/latest/` with `/$(release_name)/` and enable tag generation.