### PR TITLE
Get repos file for the release being built

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -14,7 +14,7 @@ esac
 WSDIR=$(mktemp -d)
 cd ${WSDIR}
 mkdir src
-wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/${RELEASE_NAME}/ros2.repos
+wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/release-${RELEASE_NAME}/ros2.repos
 vcs import src < ros2.repos
 colcon build --packages-up-to rclcpp_action rclpy
 wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/Makefile

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -14,7 +14,7 @@ esac
 WSDIR=$(mktemp -d)
 cd ${WSDIR}
 mkdir src
-wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/${RELEASE_NAME}/ros2.repos
 vcs import src < ros2.repos
 colcon build --packages-up-to rclcpp_action rclpy
 wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/Makefile

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -14,7 +14,7 @@ esac
 WSDIR=$(mktemp -d)
 cd ${WSDIR}
 mkdir src
-wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/release-${RELEASE_NAME}/ros2.repos
+wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/${RELEASE_NAME}-release/ros2.repos
 vcs import src < ros2.repos
 colcon build --packages-up-to rclcpp_action rclpy
 wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/Makefile


### PR DESCRIPTION
If we are building documentation for a particular release, we want to use the correct versions. This is useful if we want to this script to regenerate docs for a previous release.