### PR TITLE
Add rmw_fastrtps doc_gen Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ default: setup $(release_name) \
 	api/rclcpp_lifecycle \
 	api/rclpy
 	api/rmw \
+	api/rmw_fastrtps_cpp \
+	api/rmw_fastrtps_dynamic_cpp \
+	api/rmw_fastrtps_shared_cpp
+
 
 install: default
 	rm -r src/ros2/docs.ros2.org/$(release_name) || true
@@ -75,6 +79,21 @@ api/rclcpp_lifecycle: src/ros2/rclcpp/rclcpp_lifecycle/doc_output/html
 	cp -r $< $@
 
 api/rclpy: src/ros2/rclpy/rclpy/docs/build/html
+	rm -r $@ || true
+	test -d api || mkdir api
+	cp -r $< $@
+
+api/rmw_fastrtps_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/doc_output/html
+	rm -r $@ || true
+	test -d api || mkdir api
+	cp -r $< $@
+
+api/rmw_fastrtps_dynamic_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_dynamic_cpp/doc_output/html
+	rm -r $@ || true
+	test -d api || mkdir api
+	cp -r $< $@
+
+api/rmw_fastrtps_shared_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/doc_output/html
 	rm -r $@ || true
 	test -d api || mkdir api
 	cp -r $< $@
@@ -170,6 +189,33 @@ src/ros2/rclpy/rclpy/docs/build/html:
 	    cd src/ros2/rclpy/rclpy/docs && \
 		git clean -dfx && \
 		make html
+
+src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/doc_output/html:
+	. install/setup.sh && \
+		cd src/ros2/rmw_fastrtps/rmw_fastrtps_cpp && \
+		git clean -dfx && \
+		cmake . && make -j 8
+	rm -r $@ || true
+	rm doxygen_tag_files/rmw_fastrtps_cpp.tag || true
+	cd src/ros2/rmw_fastrtps/rmw_fastrtps_cpp && doxygen Doxyfile
+
+src/ros2/rmw_fastrtps/rmw_fastrtps_dynamic_cpp/doc_output/html:
+	. install/setup.sh && \
+		cd src/ros2/rmw_fastrtps/rmw_fastrtps_dynamic_cpp && \
+		git clean -dfx && \
+		cmake . && make -j 8
+	rm -r $@ || true
+	rm doxygen_tag_files/rmw_fastrtps_dynamic_cpp.tag || true
+	cd src/ros2/rmw_fastrtps/rmw_fastrtps_dynamic_cpp && doxygen Doxyfile
+
+src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/doc_output/html:
+	. install/setup.sh && \
+		cd src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp && \
+		git clean -dfx && \
+		cmake . && make -j 8
+	rm -r $@ || true
+	rm doxygen_tag_files/rmw_fastrtps_shared_cpp.tag || true
+	cd src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp && doxygen Doxyfile
 
 cpp-doxygen-web.tag.xml:
 	test -d doxygen_tag_files || mkdir doxygen_tag_files


### PR DESCRIPTION
The packages  `rmw_fastrtps_cpp`, `rmw_fastrtps_dynamic_cpp` and `rmw_fastrtps_shared_cpp`  now has a [doxyfile](https://github.com/ros2/rmw_fastrtps/pull/372). I'm adding a target for it to this makefile.

Related PR https://github.com/ros2/rmw_fastrtps/pull/372

Signed-off-by: ahcorde <ahcorde@gmail.com>