### PR TITLE
Add continuous integration workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -qq
-        sudo apt install -y curl doxygen python3-sphinx python3-sphinx-rtd-theme python3-sphinx-autodoc-typehints
+        sudo apt install -y curl doxygen python3-sphinx python3-sphinx-rtd-theme
+        pip3 install sphinx-autodoc-typehints
     - name: Build code and docs
       run: ${GITHUB_WORKSPACE}/build_docs.sh -y -r ${{ matrix.rosdistro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -qq
-        sudo apt install -y curl doxygen python3-sphinx python3-pip
-        sudo pip3 install sphinx-rtd-theme sphinx_autodoc_typehints
+        sudo apt install -y curl doxygen python3-sphinx python3-sphinx-rtd-theme python3-sphinx-autodoc-typehints
     - name: Build code and docs
       run: ${GITHUB_WORKSPACE}/build_docs.sh -y -r ${{ matrix.rosdistro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ doc_gen ]
+  pull_request:
+    branches: [ doc_gen ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            rosdistro: dashing
+          - os: ubuntu-18.04
+            rosdistro: eloquent
+          - os: ubuntu-20.04
+            rosdistro: foxy
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ros-tooling/setup-ros@0.0.23
+      with:
+        required-ros-distributions: ${{ matrix.rosdistro }}
+    - name: Install dependencies
+      run: |
+        sudo apt update -qq
+        sudo apt install -y curl doxygen python3-sphinx python3-pip
+        sudo pip3 install sphinx-rtd-theme sphinx_autodoc_typehints
+    - name: Build code and docs
+      run: ${GITHUB_WORKSPACE}/build_docs.sh -y -r ${{ matrix.rosdistro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
     - uses: ros-tooling/setup-ros@0.0.23
       with:
         required-ros-distributions: ${{ matrix.rosdistro }}
@@ -33,4 +30,6 @@ jobs:
         sudo apt install -y curl doxygen python3-pip
         pip3 install sphinx sphinx-rtd-theme sphinx-autodoc-typehints
     - name: Build code and docs
-      run: ${GITHUB_WORKSPACE}/build_docs.sh -y -r ${{ matrix.rosdistro }}
+      run: |
+        export PATH="/home/runner/.local/bin:$PATH"
+        ${GITHUB_WORKSPACE}/build_docs.sh -y -r ${{ matrix.rosdistro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update -qq
-        sudo apt install -y curl doxygen python3-sphinx python3-sphinx-rtd-theme
-        pip3 install sphinx-autodoc-typehints
+        sudo apt install -y curl doxygen python3-pip
+        pip3 install sphinx sphinx-rtd-theme sphinx-autodoc-typehints
     - name: Build code and docs
       run: ${GITHUB_WORKSPACE}/build_docs.sh -y -r ${{ matrix.rosdistro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - uses: ros-tooling/setup-ros@0.0.23
       with:
         required-ros-distributions: ${{ matrix.rosdistro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-18.04


### PR DESCRIPTION
Builds on top of https://github.com/ros2/docs.ros2.org/pull/39.

We have some regressions for Dashing and Eloquent (ie. the build_docs.sh script no longer worked with them); https://github.com/ros2/docs.ros2.org/pull/39 is a refactor that enables backwards compatibility, fixing the regressions. This PR adds CI to confirm that things are working and to prevent future regressions.