### PR TITLE
Major refactor of documentation generation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ src/ros2/rcl_logging/rcl_logging_spdlog/doc_output/html doxygen_tag_files/rcl_lo
 	rm doxygen_tag_files/rcl_logging_spdlog.tag || true
 	cd src/ros2/rcl_logging/rcl_logging_spdlog && doxygen Doxyfile
 
-src/ros2/rcl/rcl_yaml_param_parser/doc_output/html doxygen_tag_files/rcl_lifecycle.tag: src/ros2/rcl/rcl_yaml_param_parser/Doxyfile
+src/ros2/rcl/rcl_yaml_param_parser/doc_output/html doxygen_tag_files/rcl_yaml_param_parser.tag: src/ros2/rcl/rcl_yaml_param_parser/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcl/rcl_yaml_param_parser && \
 		git clean -dfx && \

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,9 @@
-release_name := crystal
-
-default: setup $(release_name) \
-	api/ament_index_cpp \
-	api/ament_index_python \
-	api/class_loader \
-	api/libstatistics_collector \
-	api/rcutils \
-	api/rcpputils \
-	api/rcl \
-	api/rcl_action \
-	api/rcl_lifecycle \
-	api/rcl_logging_spdlog \
-	api/rcl_yaml_param_parser \
-	api/rclcpp \
-	api/rclcpp_action \
-	api/rclcpp_components \
-	api/rclcpp_lifecycle \
-	api/rclpy \
-	api/rosidl_runtime_c \
-	api/rosidl_runtime_cpp \
-	api/rmw \
-	api/rmw_dds_common \
-	api/rmw_fastrtps_cpp \
-	api/rmw_fastrtps_dynamic_cpp \
-	api/rmw_fastrtps_shared_cpp \
-	api/tf2 \
-	api/tf2_bullet \
-	api/tf2_eigen \
-	api/tf2_geometry_msgs \
-	api/tf2_kdl \
-	api/tf2_ros \
-	api/tf2_tools
+default: setup $(release_name) $(package_names)
 
 install: default
 	rm -r src/ros2/docs.ros2.org/$(release_name) || true
 	cp -r $(release_name) src/ros2/docs.ros2.org/$(release_name)
 	cp -r api src/ros2/docs.ros2.org/$(release_name)/api
-
 
 clean:
 	rm -r $(release_name) api || true

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ src/ros2/rcutils/doc_output/html doxygen_tag_files/rcutils.tag: src/ros2/rcutils
 	rm doxygen_tag_files/rcutils.tag || true
 	cd src/ros2/rcutils && doxygen Doxyfile
 
-src/ros2/rcpputils/doc_output/html doxygen_tag_files/rcpputils.tag: src/ros2/rcpputils/Doxyfile doxygen_tag_files/rcutils.tag
+src/ros2/rcpputils/doc_output/html doxygen_tag_files/rcpputils.tag: src/ros2/rcpputils/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcpputils && \
 		git clean -dfx && \
@@ -193,7 +193,7 @@ src/ros2/rcpputils/doc_output/html doxygen_tag_files/rcpputils.tag: src/ros2/rcp
 	rm doxygen_tag_files/rcpputils.tag || true
 	cd src/ros2/rcpputils && doxygen Doxyfile
 
-src/ros2/rmw/rmw/doc_output/html doxygen_tag_files/rmw.tag: src/ros2/rmw/rmw/Doxyfile doxygen_tag_files/rcutils.tag doxygen_tag_files/rcpputils.tag
+src/ros2/rmw/rmw/doc_output/html doxygen_tag_files/rmw.tag: src/ros2/rmw/rmw/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rmw/rmw && \
 		git clean -dfx && \
@@ -211,7 +211,7 @@ src/ros2/rmw_dds_common/rmw_dds_common/doc_output/html doxygen_tag_files/rmw_dds
 	rm doxygen_tag_files/rmw_dds_common.tag || true
 	cd src/ros2/rmw_dds_common/rmw_dds_common && doxygen Doxyfile
 
-src/ros2/rcl/rcl/doc_output/html doxygen_tag_files/rcl.tag: src/ros2/rcl/rcl/Doxyfile doxygen_tag_files/rcutils.tag doxygen_tag_files/rcpputils.tag doxygen_tag_files/rmw.tag
+src/ros2/rcl/rcl/doc_output/html doxygen_tag_files/rcl.tag: src/ros2/rcl/rcl/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcl/rcl && \
 		git clean -dfx && \
@@ -220,7 +220,7 @@ src/ros2/rcl/rcl/doc_output/html doxygen_tag_files/rcl.tag: src/ros2/rcl/rcl/Dox
 	rm doxygen_tag_files/rcl.tag || true
 	cd src/ros2/rcl/rcl && doxygen Doxyfile
 
-src/ros2/rcl/rcl_action/doc_output/html doxygen_tag_files/rcl_action.tag: src/ros2/rcl/rcl_action/Doxyfile doxygen_tag_files/rcutils.tag doxygen_tag_files/rcpputils.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcl.tag
+src/ros2/rcl/rcl_action/doc_output/html doxygen_tag_files/rcl_action.tag: src/ros2/rcl/rcl_action/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcl/rcl_action && \
 		git clean -dfx && \
@@ -229,7 +229,7 @@ src/ros2/rcl/rcl_action/doc_output/html doxygen_tag_files/rcl_action.tag: src/ro
 	rm doxygen_tag_files/rcl_action.tag || true
 	cd src/ros2/rcl/rcl_action && doxygen Doxyfile
 
-src/ros2/rcl/rcl_lifecycle/doc_output/html doxygen_tag_files/rcl_lifecycle.tag: src/ros2/rcl/rcl_lifecycle/Doxyfile doxygen_tag_files/rcutils.tag doxygen_tag_files/rcpputils.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcl.tag
+src/ros2/rcl/rcl_lifecycle/doc_output/html doxygen_tag_files/rcl_lifecycle.tag: src/ros2/rcl/rcl_lifecycle/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcl/rcl_lifecycle && \
 		git clean -dfx && \
@@ -238,7 +238,7 @@ src/ros2/rcl/rcl_lifecycle/doc_output/html doxygen_tag_files/rcl_lifecycle.tag: 
 	rm doxygen_tag_files/rcl_lifecycle.tag || true
 	cd src/ros2/rcl/rcl_lifecycle && doxygen Doxyfile
 
-src/ros2/rcl_logging/rcl_logging_spdlog/doc_output/html doxygen_tag_files/rcl_logging_spdlog.tag: src/ros2/rcl_logging/rcl_logging_spdlog/Doxyfile doxygen_tag_files/rcutils.tag
+src/ros2/rcl_logging/rcl_logging_spdlog/doc_output/html doxygen_tag_files/rcl_logging_spdlog.tag: src/ros2/rcl_logging/rcl_logging_spdlog/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcl_logging/rcl_logging_spdlog && \
 		git clean -dfx && \
@@ -247,7 +247,7 @@ src/ros2/rcl_logging/rcl_logging_spdlog/doc_output/html doxygen_tag_files/rcl_lo
 	rm doxygen_tag_files/rcl_logging_spdlog.tag || true
 	cd src/ros2/rcl_logging/rcl_logging_spdlog && doxygen Doxyfile
 
-src/ros2/rcl/rcl_yaml_param_parser/doc_output/html doxygen_tag_files/rcl_lifecycle.tag: src/ros2/rcl/rcl_yaml_param_parser/Doxyfile doxygen_tag_files/rcutils.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcl.tag
+src/ros2/rcl/rcl_yaml_param_parser/doc_output/html doxygen_tag_files/rcl_lifecycle.tag: src/ros2/rcl/rcl_yaml_param_parser/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rcl/rcl_yaml_param_parser && \
 		git clean -dfx && \
@@ -256,7 +256,7 @@ src/ros2/rcl/rcl_yaml_param_parser/doc_output/html doxygen_tag_files/rcl_lifecyc
 	rm doxygen_tag_files/rcl_yaml_param_parser.tag || true
 	cd src/ros2/rcl/rcl_yaml_param_parser && doxygen Doxyfile
 
-src/ros2/rclcpp/rclcpp/doc_output/html doxygen_tag_files/rclcpp.tag: src/ros2/rclcpp/rclcpp/Doxyfile doxygen_tag_files/rcl.tag doxygen_tag_files/rcpputils.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcutils.tag
+src/ros2/rclcpp/rclcpp/doc_output/html doxygen_tag_files/rclcpp.tag: src/ros2/rclcpp/rclcpp/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rclcpp/rclcpp && \
 		git clean -dfx && \
@@ -265,7 +265,7 @@ src/ros2/rclcpp/rclcpp/doc_output/html doxygen_tag_files/rclcpp.tag: src/ros2/rc
 	rm doxygen_tag_files/rclcpp.tag || true
 	cd src/ros2/rclcpp/rclcpp && doxygen Doxyfile
 
-src/ros2/rclcpp/rclcpp_action/doc_output/html doxygen_tag_files/rclcpp_action.tag: src/ros2/rclcpp/rclcpp_action/Doxyfile doxygen_tag_files/rclcpp.tag doxygen_tag_files/rcl.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcutils.tag  doxygen_tag_files/rcpputils.tag
+src/ros2/rclcpp/rclcpp_action/doc_output/html doxygen_tag_files/rclcpp_action.tag: src/ros2/rclcpp/rclcpp_action/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rclcpp/rclcpp_action && \
 		git clean -dfx && \
@@ -274,7 +274,7 @@ src/ros2/rclcpp/rclcpp_action/doc_output/html doxygen_tag_files/rclcpp_action.ta
 	rm doxygen_tag_files/rclcpp_action.tag || true
 	cd src/ros2/rclcpp/rclcpp_action && doxygen Doxyfile
 
-src/ros2/rclcpp/rclcpp_components/doc_output/html doxygen_tag_files/rclcpp_components.tag: src/ros2/rclcpp/rclcpp_components/Doxyfile doxygen_tag_files/rclcpp.tag doxygen_tag_files/rcl.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcutils.tag
+src/ros2/rclcpp/rclcpp_components/doc_output/html doxygen_tag_files/rclcpp_components.tag: src/ros2/rclcpp/rclcpp_components/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rclcpp/rclcpp_components && \
 		git clean -dfx && \
@@ -283,7 +283,7 @@ src/ros2/rclcpp/rclcpp_components/doc_output/html doxygen_tag_files/rclcpp_compo
 	rm doxygen_tag_files/rclcpp_components.tag || true
 	cd src/ros2/rclcpp/rclcpp_components && doxygen Doxyfile
 
-src/ros2/rclcpp/rclcpp_lifecycle/doc_output/html doxygen_tag_files/rclcpp_lifecycle.tag: src/ros2/rclcpp/rclcpp_lifecycle/Doxyfile doxygen_tag_files/rclcpp.tag doxygen_tag_files/rcl.tag doxygen_tag_files/rmw.tag doxygen_tag_files/rcutils.tag  doxygen_tag_files/rcpputils.tag
+src/ros2/rclcpp/rclcpp_lifecycle/doc_output/html doxygen_tag_files/rclcpp_lifecycle.tag: src/ros2/rclcpp/rclcpp_lifecycle/Doxyfile
 	. install/setup.sh && \
 		cd src/ros2/rclcpp/rclcpp_lifecycle && \
 		git clean -dfx && \
@@ -412,6 +412,5 @@ cpp-doxygen-web.tag.xml:
 	wget 'http://upload.cppreference.com/mwiki/images/f/f8/cppreference-doxygen-web.tag.xml' \
 		-O doxygen_tag_files/cppreference-doxygen-web.tag.xml
 
-setup:
-	cpp-doxygen-web.tag.xml
+setup: cpp-doxygen-web.tag.xml
 	test -d $(api_directory_name) || mkdir $(api_directory_name)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
+api_directory_name ?= api
+
 default: setup $(release_name) $(package_names)
 
 install: default
 	rm -r src/ros2/docs.ros2.org/$(release_name) || true
 	cp -r $(release_name) src/ros2/docs.ros2.org/$(release_name)
-	cp -r api src/ros2/docs.ros2.org/$(release_name)/api
+	cp -r $(api_directory_name) src/ros2/docs.ros2.org/$(release_name)/$(api_directory_name)
 
 clean:
-	rm -r $(release_name) api || true
+	rm -r $(release_name) $(api_directory_name) || true
 
 purge:
 	rm -r src/ros2/**/doc_output src/ros2/ros_core_documentation/build src/ros2/rclpy/rclpy/docs/build || true
@@ -15,155 +17,125 @@ $(release_name): src/ros2/ros_core_documentation/build/html
 	rm -r $@ || true
 	cp -r $< $@
 
-api/ament_index_cpp: src/ament/ament_index/ament_index_cpp/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+ament_index_cpp: src/ament/ament_index/ament_index_cpp/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/ament_index_python: src/ament/ament_index/ament_index_python/docs/build/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+ament_index_python: src/ament/ament_index/ament_index_python/docs/build/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/class_loader: src/ros/class_loader/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+class_loader: src/ros/class_loader/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/libstatistics_collector: src/ros-tooling/libstatistics_collector/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+libstatistics_collector: src/ros-tooling/libstatistics_collector/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcutils: src/ros2/rcutils/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcutils: src/ros2/rcutils/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcpputils: src/ros2/rcpputils/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcpputils: src/ros2/rcpputils/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rmw: src/ros2/rmw/rmw/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rmw: src/ros2/rmw/rmw/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rmw_dds_common: src/ros2/rmw_dds_common/rmw_dds_common/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rmw_dds_common: src/ros2/rmw_dds_common/rmw_dds_common/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcl: src/ros2/rcl/rcl/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcl: src/ros2/rcl/rcl/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcl_action: src/ros2/rcl/rcl_action/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcl_action: src/ros2/rcl/rcl_action/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcl_lifecycle: src/ros2/rcl/rcl_lifecycle/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcl_lifecycle: src/ros2/rcl/rcl_lifecycle/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcl_logging_spdlog: src/ros2/rcl_logging/rcl_logging_spdlog/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcl_logging_spdlog: src/ros2/rcl_logging/rcl_logging_spdlog/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rcl_yaml_param_parser: src/ros2/rcl/rcl_yaml_param_parser/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rcl_yaml_param_parser: src/ros2/rcl/rcl_yaml_param_parser/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rclcpp: src/ros2/rclcpp/rclcpp/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rclcpp: src/ros2/rclcpp/rclcpp/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rclcpp_action: src/ros2/rclcpp/rclcpp_action/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rclcpp_action: src/ros2/rclcpp/rclcpp_action/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rclcpp_components: src/ros2/rclcpp/rclcpp_components/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rclcpp_components: src/ros2/rclcpp/rclcpp_components/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rclcpp_lifecycle: src/ros2/rclcpp/rclcpp_lifecycle/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rclcpp_lifecycle: src/ros2/rclcpp/rclcpp_lifecycle/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rclpy: src/ros2/rclpy/rclpy/docs/build/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rclpy: src/ros2/rclpy/rclpy/docs/build/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rosidl_runtime_c: src/ros2/rosidl/rosidl_runtime_c/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rosidl_runtime_c: src/ros2/rosidl/rosidl_runtime_c/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rosidl_runtime_cpp: src/ros2/rosidl/rosidl_runtime_cpp/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rosidl_runtime_cpp: src/ros2/rosidl/rosidl_runtime_cpp/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rmw_fastrtps_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rmw_fastrtps_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rmw_fastrtps_dynamic_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_dynamic_cpp/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rmw_fastrtps_dynamic_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_dynamic_cpp/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/rmw_fastrtps_shared_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+rmw_fastrtps_shared_cpp: src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2: src/ros2/geometry2/tf2/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2: src/ros2/geometry2/tf2/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2_bullet: src/ros2/geometry2/tf2_bullet/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2_bullet: src/ros2/geometry2/tf2_bullet/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2_eigen: src/ros2/geometry2/tf2_eigen/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2_eigen: src/ros2/geometry2/tf2_eigen/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2_geometry_msgs: src/ros2/geometry2/tf2_geometry_msgs/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2_geometry_msgs: src/ros2/geometry2/tf2_geometry_msgs/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2_kdl: src/ros2/geometry2/tf2_kdl/docs/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2_kdl: src/ros2/geometry2/tf2_kdl/docs/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2_ros: src/ros2/geometry2/tf2_ros/docs/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2_ros: src/ros2/geometry2/tf2_ros/docs/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
-api/tf2_tools: src/ros2/geometry2/tf2_tools/doc_output/html
-	rm -r $@ || true
-	test -d api || mkdir api
-	cp -r $< $@
+tf2_tools: src/ros2/geometry2/tf2_tools/doc_output/html
+	rm -r $(api_directory_name)/$@ || true
+	cp -r $< $(api_directory_name)/$@
 
 src/ros2/ros_core_documentation/build/html: src/ros2/ros_core_documentation/Makefile
 	rm -r $@ || true
@@ -440,4 +412,6 @@ cpp-doxygen-web.tag.xml:
 	wget 'http://upload.cppreference.com/mwiki/images/f/f8/cppreference-doxygen-web.tag.xml' \
 		-O doxygen_tag_files/cppreference-doxygen-web.tag.xml
 
-setup: cpp-doxygen-web.tag.xml
+setup:
+	cpp-doxygen-web.tag.xml
+	test -d $(api_directory_name) || mkdir $(api_directory_name)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-## Generating static docs for a ros2 release
+## Generating static API documentation for a ROS 2 release
 
   - Update ros2/ros_core_documentation as appropriate; install dependencies mentioned in its readme and Doxygen.
     - Specifically you'll want to update the release name, see: https://github.com/ros2/ros_core_documentation/pull/7
-  - Set the name of the release for building docs, for example, "dashing":
-    
-        export RELEASE_NAME=dashing
 
-  - Run the build script:
+  - Clone this repo and checkout the `doc_gen` branch:
 
-        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/build_docs.sh)"
+        git clone https://github.com/docs.ros2.org.git -b doc_gen
+
+  - Run the build script using the `-r` option to select the release codename:
+
+        docs.ros2.org/build_docs.sh -r foxy
 
   - Check that the following are working:
       - Cross-references between packages, e.g. `rmw` links from `rcl` docs.

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -69,11 +69,6 @@ sed -i "s/#\s*GENERATE_TAGFILE/GENERATE_TAGFILE/g" $(find src -name Doxyfile)
 # Change the ROS 2 TAGFILES links so that they reference docs.ros2.org/<release name> instead of latest
 sed -i "s/\(^TAGFILES.*docs\.ros2\.org\/\)latest/\1${RELEASE_NAME}/g" $(find src -name Doxyfile)
 
-# Append "api/" to package names for use in Makefile
-for i in "${!package_names[@]}"; do
-  package_names[$i]="api/${package_names[$i]}"
-done
-
 # Build the docs
 make install release_name=${RELEASE_NAME} package_names=${package_names[@]}
 

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -97,7 +97,7 @@ fi
 
 
 if [ 0 -eq ${opt_interactive} ]; then
-  echo "Bulding docs with the following configuration:"
+  echo "Building docs with the following configuration:"
   echo "    Release name: ${opt_release_name}"
   echo "    Repos file: ${repos_file_url}"
   echo "    Packages: ${package_names}"

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -12,9 +12,6 @@ esac
 
 # Determine package list based on ROS distro
 package_names=(
-  ament_index_cpp
-  ament_index_python
-  class_loader
   rcutils
   rcl
   rcl_action
@@ -43,7 +40,11 @@ package_names=(
 if [[ "foxy" == "${RELEASE_NAME}" ]]; then
   # Packages since Foxy
   package_names+=(
+    ament_index_cpp
+    ament_index_python
+    class_loader
     libstatistics_collector
+    rcpputils
     rmw_dds_common
     rosidl_runtime_c
     rosidl_runtime_cpp
@@ -62,9 +63,6 @@ colcon build --packages-up-to ${package_names[@]}
 wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/Makefile
 wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/ros2_doc.repos
 vcs import src < ros2_doc.repos
-
-# Update release name in Makefile
-sed -i "s/release_name :=.*$/release_name := ${RELEASE_NAME}/" Makefile
 
 # Uncomment Doxyfile lines for generating tag files
 sed -i "s/#\s*GENERATE_TAGFILE/GENERATE_TAGFILE/g" $(find src -name Doxyfile)

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -44,7 +44,7 @@ done
 shift $((OPTIND-1))
 
 if [ -z ${opt_repos+x} ]; then
-  repos_file_url=https://raw.githubusercontent.com/ros2/ros2/${opt_rosdistro}-release/ros2.repos
+  repos_file_url=https://raw.githubusercontent.com/ros2/ros2/${opt_rosdistro}/ros2.repos
 else
   repos_file_url=${opt_repos}
 fi
@@ -72,8 +72,7 @@ else
       class_loader
       libstatistics_collector
       rcl_lifecycle
-      # TODO(jacobperron): Add rcl_logging_spdlog after https://github.com/ros2/rcl_logging/pull/42 is released
-      # rcl_logging_spdlog
+      rcl_logging_spdlog
       rclcpp_lifecycle
       rcpputils
       rmw_dds_common

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -2,14 +2,14 @@
 set -e
 
 # Default options
-opt_release_name=${ROS_DISTRO:-foxy}
+opt_rosdistro=${ROS_DISTRO:-foxy}
 opt_interactive=0
 unset opt_repos
 
 print_usage() {
   echo "usage: $0 [-r DISTRO] [-e URL] [-y] [-h] [package [package ...]]"
   echo ""
-  echo "  -r DISTRO  Set the name of the ROS distribution (default: ${opt_release_name})"
+  echo "  -r DISTRO  Set the name of the ROS distribution (default: ${opt_rosdistro})"
   echo "             This also determines the version of repositories unless the '-e' option is given."
   echo "  -e URL     Location of a ROS 2 repos file to use instead of a release repos file."
   echo "  -y         Run the script in non-interactive mode"
@@ -23,7 +23,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 while getopts "r:e:yh" opt; do
   case "${opt}" in
     r)
-      opt_release_name=${OPTARG}
+      opt_rosdistro=${OPTARG}
       ;;
     e)
       opt_repos=${OPTARG}
@@ -44,7 +44,7 @@ done
 shift $((OPTIND-1))
 
 if [ -z ${opt_repos+x} ]; then
-  repos_file_url=https://raw.githubusercontent.com/ros2/ros2/${opt_release_name}-release/ros2.repos
+  repos_file_url=https://raw.githubusercontent.com/ros2/ros2/${opt_rosdistro}-release/ros2.repos
 else
   repos_file_url=${opt_repos}
 fi
@@ -65,7 +65,7 @@ else
     rmw
   )
   # Append additional default packages for Foxy
-  if [[ "foxy" == "${opt_release_name}" ]]; then
+  if [[ "foxy" == "${opt_rosdistro}" ]]; then
     package_names+=(
       ament_index_cpp
       ament_index_python
@@ -98,7 +98,7 @@ fi
 
 if [ 0 -eq ${opt_interactive} ]; then
   echo "Building docs with the following configuration:"
-  echo "    Release name: ${opt_release_name}"
+  echo "    Release name: ${opt_rosdistro}"
   echo "    Repos file: ${repos_file_url}"
   echo "    Packages: ${package_names}"
   echo ""
@@ -118,7 +118,7 @@ mkdir src
 curl -o ros2.repos ${repos_file_url}
 vcs import src < ros2.repos
 rosdep update
-rosdep install --rosdistro ${opt_release_name} --from-paths src -iry
+rosdep install --rosdistro ${opt_rosdistro} --from-paths src -iry
 colcon build --packages-up-to ${package_names}
 
 # Clone documentation-specific repos
@@ -127,7 +127,7 @@ vcs import src < ${script_dir}/ros2_doc.repos
 # Uncomment Doxyfile lines for generating tag files
 sed -i "s/#\s*GENERATE_TAGFILE/GENERATE_TAGFILE/g" $(find src -name Doxyfile)
 # Change the ROS 2 TAGFILES links so that they reference docs.ros2.org/<release name> instead of latest
-sed -i "s/\(^TAGFILES.*docs\.ros2\.org\/\)latest/\1${opt_release_name}/g" $(find src -name Doxyfile)
+sed -i "s/\(^TAGFILES.*docs\.ros2\.org\/\)latest/\1${opt_rosdistro}/g" $(find src -name Doxyfile)
 
 # Sort packages topologically so that Doxygen tags are available for packages later in order
 sorted_packages=$(colcon list --names-only -t --packages-select ${package_names})
@@ -136,7 +136,7 @@ sorted_packages=$(colcon list --names-only -t --packages-select ${package_names}
 cp ${script_dir}/Makefile .
 
 # Build the docs
-make install release_name=${opt_release_name} package_names=${sorted_packages}
+make install release_name=${opt_rosdistro} package_names=${sorted_packages}
 
 echo "Documentation has been generated and copied into '${workspace_dir}/src/ros2/docs.ros2.org'."
 echo ""

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -117,6 +117,8 @@ cd ${workspace_dir}
 mkdir src
 curl -o ros2.repos ${repos_file_url}
 vcs import src < ros2.repos
+rosdep update
+rosdep install --rosdistro ${opt_release_name} --from-paths src -iry
 colcon build --packages-up-to ${package_names}
 
 # Clone documentation-specific repos

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -1,78 +1,142 @@
 #!/usr/bin/env bash
 set -e
 
-: ${RELEASE_NAME:=dashing}
+# Default options
+opt_release_name=${ROS_DISTRO:-foxy}
+opt_interactive=0
+unset opt_repos
 
-read -p "Build docs for '${RELEASE_NAME}'? (Yn) " yn
-case $yn in
-  [Yy]* ) ;;
-  [Nn]* ) exit;;
-  * ) echo "Please answer yes or no."; exit;;
-esac
+print_usage() {
+  echo "usage: $0 [-r DISTRO] [-e URL] [-y] [-h] [package [package ...]]"
+  echo ""
+  echo "  -r DISTRO  Set the name of the ROS distribution (default: ${opt_release_name})"
+  echo "             This also determines the version of repositories unless the '-e' option is given."
+  echo "  -e URL     Location of a ROS 2 repos file to use instead of a release repos file."
+  echo "  -y         Run the script in non-interactive mode"
+  echo "  -h         Display this help message"
+}
 
-# Determine package list based on ROS distro
-package_names=(
-  rcutils
-  rcl
-  rcl_action
-  rcl_lifecycle
-  rcl_yaml_param_parser
-  rclcpp
-  rclcpp_action
-  rclcpp_components
-  rclcpp_lifecycle
-  rclpy
-  rmw
-  rmw_fastrtps_cpp
-  rmw_fastrtps_dynamic_cpp
-  rmw_fastrtps_shared_cpp
-  tf2
-  tf2_eigen
-  tf2_geometry_msgs
-  tf2_kdl
-  tf2_ros
-)
-# if [[ "eloquent" == "${RELEASE_NAME}" || "foxy" == "${RELEASE_NAME}" ]]; then
-  # Packages since Eloquent
-  # TODO(jacobperron): Add rcl_logging_spdlog after https://github.com/ros2/rcl_logging/pull/42 is backported and released
-  # package_names+=(rcl_logging_spdlog)
-# fi
-if [[ "foxy" == "${RELEASE_NAME}" ]]; then
-  # Packages since Foxy
-  package_names+=(
-    ament_index_cpp
-    ament_index_python
-    class_loader
-    libstatistics_collector
-    rcpputils
-    rmw_dds_common
-    rosidl_runtime_c
-    rosidl_runtime_cpp
-    tf2_bullet
-    tf2_tools
-  )
+# Path to this file
+# Taken from SO post https://stackoverflow.com/a/246128
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+while getopts "r:e:yh" opt; do
+  case "${opt}" in
+    r)
+      opt_release_name=${OPTARG}
+      ;;
+    e)
+      opt_repos=${OPTARG}
+      ;;
+    y)
+      opt_interactive=1
+      ;;
+    h)
+      print_usage
+      exit 0
+      ;;
+    *)
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z ${opt_repos+x} ]; then
+  repos_file_url=https://raw.githubusercontent.com/ros2/ros2/${opt_release_name}-release/ros2.repos
+else
+  repos_file_url=${opt_repos}
 fi
 
-# Setup and build workspace
-WSDIR=$(mktemp -d)
-cd ${WSDIR}
+if [ $# -gt 0 ]; then
+  package_names=$@
+else
+  # If no packages are provided as arguments, use defaults
+  package_names=(
+    rcutils
+    rcl
+    rcl_action
+    rcl_yaml_param_parser
+    rclcpp
+    rclcpp_action
+    rclcpp_components
+    rclpy
+    rmw
+    rmw_fastrtps_cpp
+    rmw_fastrtps_dynamic_cpp
+    rmw_fastrtps_shared_cpp
+  )
+  # Append additional default packages for Foxy
+  if [[ "foxy" == "${opt_release_name}" ]]; then
+    package_names+=(
+      ament_index_cpp
+      ament_index_python
+      class_loader
+      libstatistics_collector
+      rcl_lifecycle
+      # TODO(jacobperron): Add rcl_logging_spdlog after https://github.com/ros2/rcl_logging/pull/42 is released
+      # rcl_logging_spdlog
+      rclcpp_lifecycle
+      rcpputils
+      rmw_dds_common
+      rosidl_runtime_c
+      rosidl_runtime_cpp
+      tf2
+      tf2_bullet
+      tf2_eigen
+      tf2_geometry_msgs
+      tf2_kdl
+      tf2_ros
+      tf2_tools
+    )
+  fi
+  # Convert bash array to string
+  package_names=${package_names[@]}
+fi
+
+
+if [ 0 -eq ${opt_interactive} ]; then
+  echo "Bulding docs with the following configuration:"
+  echo "    Release name: ${opt_release_name}"
+  echo "    Repos file: ${repos_file_url}"
+  echo "    Packages: ${package_names}"
+  echo ""
+  read -p "Is this correct? (Yn) " yn
+  case $yn in
+    [Yy]* ) ;;
+    [Nn]* ) exit;;
+    * ) echo "Please answer yes or no."; exit;;
+  esac
+fi
+
+# Build code
+workspace_dir=$(mktemp -d)
+echo "Building workspace in the directory '${workspace_dir}'"
+cd ${workspace_dir}
 mkdir src
-wget -O ros2.repos https://raw.githubusercontent.com/ros2/ros2/${RELEASE_NAME}-release/ros2.repos
+curl -o ros2.repos ${repos_file_url}
 vcs import src < ros2.repos
-colcon build --packages-up-to ${package_names[@]}
-wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/Makefile
-wget https://raw.githubusercontent.com/ros2/docs.ros2.org/doc_gen/ros2_doc.repos
-vcs import src < ros2_doc.repos
+colcon build --packages-up-to ${package_names}
+
+# Clone documentation-specific repos
+vcs import src < ${script_dir}/ros2_doc.repos
 
 # Uncomment Doxyfile lines for generating tag files
 sed -i "s/#\s*GENERATE_TAGFILE/GENERATE_TAGFILE/g" $(find src -name Doxyfile)
 # Change the ROS 2 TAGFILES links so that they reference docs.ros2.org/<release name> instead of latest
-sed -i "s/\(^TAGFILES.*docs\.ros2\.org\/\)latest/\1${RELEASE_NAME}/g" $(find src -name Doxyfile)
+sed -i "s/\(^TAGFILES.*docs\.ros2\.org\/\)latest/\1${opt_release_name}/g" $(find src -name Doxyfile)
+
+# Sort packages topologically so that Doxygen tags are available for packages later in order
+sorted_packages=$(colcon list --names-only -t --packages-select ${package_names})
+
+# Copy Makefile to current directory
+cp ${script_dir}/Makefile .
 
 # Build the docs
-make install release_name=${RELEASE_NAME} package_names=${package_names[@]}
+make install release_name=${opt_release_name} package_names=${sorted_packages}
 
-echo "Documentation has been generated and copied into '${WSDIR}/src/ros2/docs.ros2.org'."
+echo "Documentation has been generated and copied into '${workspace_dir}/src/ros2/docs.ros2.org'."
 echo ""
 echo "Before commiting:"
 echo "  1) Check that cross-references between packages, external references, and references to generated files are working."

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -63,9 +63,6 @@ else
     rclcpp_components
     rclpy
     rmw
-    rmw_fastrtps_cpp
-    rmw_fastrtps_dynamic_cpp
-    rmw_fastrtps_shared_cpp
   )
   # Append additional default packages for Foxy
   if [[ "foxy" == "${opt_release_name}" ]]; then
@@ -80,6 +77,9 @@ else
       rclcpp_lifecycle
       rcpputils
       rmw_dds_common
+      rmw_fastrtps_cpp
+      rmw_fastrtps_dynamic_cpp
+      rmw_fastrtps_shared_cpp
       rosidl_runtime_c
       rosidl_runtime_cpp
       tf2

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -25,20 +25,15 @@ package_names=(
   rclcpp_components
   rclcpp_lifecycle
   rclpy
-  rosidl_runtime_c
-  rosidl_runtime_cpp
   rmw
-  rmw_dds_common
   rmw_fastrtps_cpp
   rmw_fastrtps_dynamic_cpp
   rmw_fastrtps_shared_cpp
   tf2
-  tf2_bullet
   tf2_eigen
   tf2_geometry_msgs
   tf2_kdl
   tf2_ros
-  tf2_tools
 )
 # if [[ "eloquent" == "${RELEASE_NAME}" || "foxy" == "${RELEASE_NAME}" ]]; then
   # Packages since Eloquent
@@ -47,7 +42,14 @@ package_names=(
 # fi
 if [[ "foxy" == "${RELEASE_NAME}" ]]; then
   # Packages since Foxy
-  package_names+=(libstatistics_collector)
+  package_names+=(
+    libstatistics_collector
+    rmw_dds_common
+    rosidl_runtime_c
+    rosidl_runtime_cpp
+    tf2_bullet
+    tf2_tools
+  )
 fi
 
 # Setup and build workspace


### PR DESCRIPTION
In an effort to make the `build_docs.sh` script backwards compatible with ROS distros older than Foxy, I ended up making a few quality of life improvements.

Now we can optionally pass specific packages to build to the script, or default to a set of known packages that work for a given ROS release.

Rather than relying on an environment variable, we now set the ROS distro with the `-r` option.

For convenience of debugging/testing we can also override the repos file entirely with `-e`. 

Since I want to enable CI for future changes to prevent regression, I've also added a non-interactive mode.

Here's a summary of usage:

```
usage: ./build_docs.sh [-r DISTRO] [-e URL] [-y] [-h] [package [package ...]]

  -r DISTRO  Set the name of the ROS distribution (default: foxy)
             This also determines the version of repositories unless the '-e' option is given.
  -e URL     Location of a ROS 2 repos file to use instead of a release repos file.
  -y         Run the script in non-interactive mode
  -h         Display this help message
```

In addition to the interface changes, I've removed the strict dependencies on Doxygen tag files from the Makefile targets. This was necessary if we want to be able to build documentation for a subset of packages (which happens naturally if we want to build docs for Dashing, for example). I don't think this should effect the final HTML output as long as we build the documentation in topological order, hence:

https://github.com/ros2/docs.ros2.org/blob/fad4e63448406b63b24a0714688d38e2b5dd41ce/build_docs.sh#L130-L131